### PR TITLE
Settings system

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -37,7 +37,10 @@ local globalMethods = {
     isXClosure = is_synapse_function or issentinelclosure or is_protosmasher_closure or is_sirhurt_closure or checkclosure
 }
 
-local web = true
+local settings = (...) or {}
+settings.web = settings.web or true
+settings.branch = settings.branch or "Upbolt/Hydroxide/revision"
+
 local function import(asset)
     if importCache[asset] then
         return unpack(importCache[asset])
@@ -47,8 +50,8 @@ local function import(asset)
 
     if asset:find("rbxassetid://") then
         assets = { game:GetObjects(asset)[1] }
-    elseif web then
-        assets = { loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/Upbolt/Hydroxide/revision/" .. asset .. ".lua"))() }
+    elseif settings.web then
+        assets = { loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/" .. settings.branch .. "/" .. asset .. ".lua"), "Hydroxide/" .. asset ..".lua")() }
     else
         assets = { loadfile("hydroxide/" .. asset .. ".lua")() }
     end
@@ -78,6 +81,7 @@ end
 environment.import = import
 environment.hasMethods = hasMethods
 environment.oh = {
+    Settings = {},
     Events = {},
     Hooks = {},
     Methods = globalMethods,

--- a/init.lua
+++ b/init.lua
@@ -38,7 +38,7 @@ local globalMethods = {
 }
 
 local settings = (...) or {}
-settings.web = settings.web or true
+settings.web = (settings.web == nil and true) or settings.web
 settings.branch = settings.branch or "Upbolt/Hydroxide/revision"
 
 local function import(asset)


### PR DESCRIPTION
This adds a "settings" system to Hydroxide. The user can pass a table, as an argument, to the init.lua function.
Currently, this table only lets the user configure if Hydroxide loads from the web and what branch it should load from, but the settings table is put in the "oh" global table so other files other than init.lua can access it.
This also adds the second argument to loadstring() (chunk names) for easier debugging of Hydroxide.
^ example showing chunk names:
https://gyazo.com/b7b8c64cd2ef1ca9cb34ddc4badfd059
Script used to test this:
```lua
local branch = "Kan18/Hydroxide/revision"

local function importAsset(asset)
	return loadstring(game:HttpGetAsync(
		"https://raw.githubusercontent.com/"..branch.."/"..asset..".lua"
	))
end

importAsset("init")({
	branch = branch,
	web = true
})

importAsset("ui/main")()
```
Alternate version of above script that loads from disk:
```lua
loadfile("Hydroxide/init.lua")({
	web = false
})

loadfile("Hydroxide/ui/main.lua")()
```