### PR TITLE
Updated Constant.update to work with PS Api.

### DIFF
--- a/objects/Constant.lua
+++ b/objects/Constant.lua
@@ -19,7 +19,7 @@ end
 
 function Constant.update(constant)
     if is_protosmasher_caller() then
-        local PS_ThreadConstants = debug.getconstants(constant.Closure)
+        local PS_ThreadConstants = getConstants(constant.Closure)
         constant.Value = PS_ThreadConstants[constant.Index]
     else
         constant.Value = getConstant(constant.Closure, constant.Index)

--- a/objects/Constant.lua
+++ b/objects/Constant.lua
@@ -18,7 +18,12 @@ function Constant.set(constant, index, value)
 end
 
 function Constant.update(constant)
-    constant.Value = getConstant(constant.Closure, constant.Index)
+    if is_protosmasher_caller() then
+        local PS_ThreadConstants = debug.getconstants(constant.Closure)
+        constant.Value = PS_ThreadConstants[constant.Index]
+    else
+        constant.Value = getConstant(constant.Closure, constant.Index)
+    end
 end
 
 return Constant


### PR DESCRIPTION
Since for some reason there is no direct getconstant in the ProtoSmasher debug library, I added an exception to where if the thread is a protosmasher caller, it returns a table of constants within the closure provided and indexes them with constant.Index