### PR TITLE
Temporary ScriptScanner fix for PS Api.

### DIFF
--- a/objects/LocalScript.lua
+++ b/objects/LocalScript.lua
@@ -7,7 +7,12 @@ function LocalScript.new(instance)
     localScript.Instance = instance
     localScript.Environment = getSenv(instance)
     localScript.Constants = getConstants(closure)
-    localScript.Protos = getProtos(closure)
+
+    if is_protosmasher_caller() then
+        localScript.Protos = {nil}
+    else
+        localScript.Protos = getProtos(closure)
+    end
 
     return localScript
 end


### PR DESCRIPTION
Make localscript.Protos nil until Slappy adds debug.getProtos()