### PR TITLE
Broken Code/Security Hole

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 ## Script
 ```lua
-local owner = "Upbolt"
+local owner = "CandyWirus"
 local branch = "revision"
 
 local function webImport(file)
     return loadstring(game:HttpGetAsync(("https://raw.githubusercontent.com/%s/Hydroxide/%s/%s.lua"):format(owner, branch, file)), file .. '.lua')()
 end
+
+shared.Dihydroxide = {}
+shared.Dihydroxide.owner = owner
+shared.Dihydroxide.branch = branch
 
 webImport("init")
 webImport("ui/main")

--- a/init.lua
+++ b/init.lua
@@ -173,29 +173,6 @@ environment.oh = {
     end
 }
 
-if getConnections then 
-    for __, connection in pairs(getConnections(game:GetService("ScriptContext").Error)) do
-
-        local conn = getrawmetatable(connection)
-        local old = conn.__index
-        if PROTOSMASHER_LOADED ~= nil then setWriteable(conn) else setReadOnly(conn, false) end
-        conn.__index = newcclosure(function(t, k)
-            if k == "Connected" then
-                return true
-            end
-            return old(t, k)
-        end)
-
-        if PROTOSMASHER_LOADED ~= nil then
-            setReadOnly(conn)
-            connection:Disconnect()
-        else
-            setReadOnly(conn, true)
-            connection:Disable()
-        end
-    end
-end
-
 useMethods(globalMethods)
 useMethods(import("methods/string"))
 useMethods(import("methods/table"))

--- a/init.lua
+++ b/init.lua
@@ -80,6 +80,7 @@ local globalMethods = {
     isLClosure = islclosure or is_l_closure or (iscclosure and function(closure) return not iscclosure(closure) end),
     isReadOnly = isreadonly or is_readonly,
     isXClosure = is_synapse_function or issentinelclosure or is_protosmasher_closure or is_sirhurt_closure or iselectronfunction or checkclosure,
+	identifyexecutor = identifyexecutor
 }
 
 if PROTOSMASHER_LOADED ~= nil then

--- a/init.lua
+++ b/init.lua
@@ -1,4 +1,4 @@
-local environment = assert(getgenv, "<OH> ~ Your exploit is not supported")()
+local environment = assert(getgenv, "<OH> ~ Your exploit is not supported")
 
 if oh then
     oh.Exit()
@@ -29,7 +29,7 @@ end
 
 local function hasMethods(methods)
     for name in pairs(methods) do
-        if not environment[name] then
+        if not environment()[name] then
             return false
         end
     end
@@ -40,7 +40,7 @@ end
 local function useMethods(module)
     for name, method in pairs(module) do
         if method then
-            environment[name] = method
+            environment()[name] = method
         end
     end
 end
@@ -79,8 +79,7 @@ local globalMethods = {
     setReadOnly = setreadonly or (make_writeable and function(table, readonly) if readonly then make_readonly(table) else make_writeable(table) end end),
     isLClosure = islclosure or is_l_closure or (iscclosure and function(closure) return not iscclosure(closure) end),
     isReadOnly = isreadonly or is_readonly,
-    isXClosure = is_synapse_function or issentinelclosure or is_protosmasher_closure or is_sirhurt_closure or iselectronfunction or checkclosure,
-	identifyexecutor = identifyexecutor
+    isXClosure = is_synapse_function or issentinelclosure or is_protosmasher_closure or is_sirhurt_closure or iselectronfunction or checkclosure
 }
 
 if PROTOSMASHER_LOADED ~= nil then
@@ -108,9 +107,9 @@ globalMethods.getUpvalues = function(closure)
     return oldGetUpvalues(closure)
 end
 
-environment.import = import
-environment.hasMethods = hasMethods
-environment.oh = {
+environment().import = import
+environment().hasMethods = hasMethods
+environment().oh = {
     Events = {},
     Hooks = {},
     Methods = globalMethods,

--- a/init.lua
+++ b/init.lua
@@ -5,7 +5,7 @@ if oh then
 end
 
 local web = true
-local user = "Upbolt" -- change if you're using a fork
+local user = "CandyWirus" -- change if you're using a fork
 local importCache = {}
 
 local function import(asset)

--- a/init.lua
+++ b/init.lua
@@ -79,7 +79,8 @@ local globalMethods = {
     setReadOnly = setreadonly or (make_writeable and function(table, readonly) if readonly then make_readonly(table) else make_writeable(table) end end),
     isLClosure = islclosure or is_l_closure or (iscclosure and function(closure) return not iscclosure(closure) end),
     isReadOnly = isreadonly or is_readonly,
-    isXClosure = is_synapse_function or issentinelclosure or is_protosmasher_closure or is_sirhurt_closure or iselectronfunction or checkclosure
+    isXClosure = is_synapse_function or issentinelclosure or is_protosmasher_closure or is_sirhurt_closure or iselectronfunction or checkclosure,
+	identifyexecutor = identifyexecutor
 }
 
 if PROTOSMASHER_LOADED ~= nil then

--- a/modules/RemoteSpy.lua
+++ b/modules/RemoteSpy.lua
@@ -12,6 +12,7 @@ local requiredMethods = {
     ["setClipboard"] = true,
     ["getNamecallMethod"] = true,
     ["getCallingScript"] = true,
+	["identifyexecutor"] = true
 }
 
 local remoteMethods = {
@@ -55,7 +56,7 @@ end
 
 setReadOnly(gmt, false)
 
-gmt.__namecall = newCClosure(function(instance, ...)
+local function namecallFunction(instance, ...)
     if not checkCaller() and remotesViewing[instance.ClassName] and instance ~= remoteDataEvent and remoteMethods[getNamecallMethod()] then
         local remote = currentRemotes[instance]
         local vargs = {...}
@@ -86,7 +87,14 @@ gmt.__namecall = newCClosure(function(instance, ...)
     end
 
     return nmc(instance, ...)
-end)
+end
+
+if identifyexecutor() == "ScriptWare" then
+	local old
+	old = hookfunction(gmt.__namecall, function(...) namecallFunction(...) end)
+elseif syn then
+	gmt.__namecall = namecallFunction
+end
 
 for _name, hook in pairs(methodHooks) do
     local originalMethod


### PR DESCRIPTION
Removed the error disabler as it opens a security hole in Hydroxide. More importantly, the error disabler didn't work as it referenced `getConnections` before it was added to the global environment.

If this did in fact work, the vulnerability would be detected at [https://www.roblox.com/games/4841850115/Test-Place](url)