### PR TITLE
fix ModuleScript vulnerability

### DIFF
--- a/objects/ModuleScript.lua
+++ b/objects/ModuleScript.lua
@@ -7,7 +7,7 @@ function ModuleScript.new(instance)
     moduleScript.Instance = instance
     moduleScript.Constants = getConstants(closure)
     moduleScript.Protos = getProtos(closure)
-    moduleScript.ReturnValue = require(instance)
+    --moduleScript.ReturnValue = require(instance) // causes detection
 
     return moduleScript
 end


### PR DESCRIPTION
fix useless require being called on every module on the game (simply add a return wait(9e9) on your module or whatever and it would break hydroxide)