### PR TITLE
Update RemoteSpy.lua

### DIFF
--- a/ui/modules/RemoteSpy.lua
+++ b/ui/modules/RemoteSpy.lua
@@ -859,7 +859,7 @@ scriptContext:SetCallback(function()
             local robloxValueType = typeof(v)
             local variableName = robloxValueType:sub(1, 1):upper() .. robloxValueType:sub(2)
 
-            if valueType == "userdata" then
+            if valueType == "userdata" or valueType == "vector" then
                 v = (typeof(v) == "Instance" and getInstancePath(v)) or userdataValue(v)
             elseif valueType == "table" then
                 v = tableToString(v)


### PR DESCRIPTION
Fixes the issue where `type(Vector3.new(x, y, z))` returns vector, rather than userdata, leading to Hydroxide returning it as `tostring(data)` instead of `typeof(Vector3.new(x, y, z)) .. ".new(" .. tostring(data) .. ")"` when generating pseudocode.

If my explanation makes no sense, generate pseudocode for a remote that has a Vector3 as an argument, and compare the result between my fork and the original.