### PR TITLE
Fix script generator putting "userdata: address" into the constant table

### DIFF
--- a/methods/userdata.lua
+++ b/methods/userdata.lua
@@ -41,7 +41,7 @@ local function userdataValue(data)
     local dataType = typeof(data)
 
     if dataType == "userdata" then
-        return toString(data)
+        return "aux.placeholderUserdataConstant"
     elseif dataType == "Instance" then
         return data.Name
     elseif dataType == "BrickColor" then

--- a/ohaux.lua
+++ b/ohaux.lua
@@ -9,6 +9,8 @@ local isLClosure = islclosure or is_l_closure or (iscclosure and function(f) ret
 
 assert(getGc and getInfo and getConstants and isXClosure, "Your exploit is not supported")
 
+local placeholderUserdataConstant = newproxy(false)
+
 local function matchConstants(closure, list)
     if not list then
         return true
@@ -16,8 +18,8 @@ local function matchConstants(closure, list)
     
     local constants = getConstants(closure)
     
-    for index in pairs(list) do
-        if not constants[index] then
+    for index, value in pairs(list) do
+        if constants[index] ~= value and value ~= placeholderUserdataConstant then
             return false
         end
     end
@@ -46,6 +48,7 @@ local function searchClosure(script, name, upvalueIndex, constants)
     end
 end
 
+aux.placeholderUserdataConstant = placeholderUserdataConstant
 aux.searchClosure = searchClosure
 
 return aux


### PR DESCRIPTION
Recently, the Synapse team revealed an apparent vulnerability with the debug library. Among the fixes they listed, they said that you need to get rid of any functions returned by `debug.getconstant(s)`. The way that they fixed it is replacing the values with new blank userdatas. This affected the script generator, as in the constant table string, it would generate "userdata: address". This fixes this problem by adding a wildcard placeholder `aux.placeholderUserdataConstant` that gets skipped when checking constants.