### PR TITLE
change .oh to .txt for synapse 3.0 compatibility

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -187,7 +187,7 @@ local releaseInfo = HttpService:JSONDecode(game:HttpGetAsync("https://api.github
 
 if readFile and writeFile then
     local hasFolderFunctions = (isFolder and makeFolder) ~= nil
-    local ran, result = pcall(readFile, "version.oh")
+    local ran, result = pcall(readFile, "hydroxide_version.txt")
 
     if not ran or releaseInfo.tag_name ~= result then
         if hasFolderFunctions then
@@ -248,7 +248,7 @@ if readFile and writeFile then
             return unpack(assets)
         end
 
-        writeFile("version.oh", releaseInfo.tag_name)
+        writeFile("hydroxide_version.txt", releaseInfo.tag_name)
     elseif ran and releaseInfo.tag_name == result then
         function environment.import(asset)
             if importCache[asset] then


### PR DESCRIPTION
the file name isn't very good but it can be changed ig. this is just because synapse 3.0 has a file extension whitelist.