### PR TITLE
Change file extension of the version file for Synapse V3 compatibility

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -187,7 +187,7 @@ local releaseInfo = HttpService:JSONDecode(game:HttpGetAsync("https://api.github
 
 if readFile and writeFile then
     local hasFolderFunctions = (isFolder and makeFolder) ~= nil
-    local ran, result = pcall(readFile, "version.oh")
+    local ran, result = pcall(readFile, "version.txt")
 
     if not ran or releaseInfo.tag_name ~= result then
         if hasFolderFunctions then
@@ -248,7 +248,7 @@ if readFile and writeFile then
             return unpack(assets)
         end
 
-        writeFile("version.oh", releaseInfo.tag_name)
+        writeFile("version.txt", releaseInfo.tag_name)
     elseif ran and releaseInfo.tag_name == result then
         function environment.import(asset)
             if importCache[asset] then


### PR DESCRIPTION
Synapse V3 does not support some file formats, that includes files with the `.oh` extension.

Changing the version file from `.oh` to `.txt` will not only make it compatible with Synapse V3 as it will not affect the other script executors.