### PR TITLE
Detection + Bug Fixes

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -112,6 +112,7 @@ environment.oh = {
             userdata = "rbxassetid://4666594723",
             vector = "rbxassetid://4666594723",
             ["function"] = "rbxassetid://4666593447",
+            ["thread"] = "rbxassetid://4666593447",
             ["integral"] = "rbxassetid://4666593882"
         },
         Syntax = {
@@ -123,6 +124,7 @@ environment.oh = {
             userdata = Color3.fromRGB(225, 225, 225),
             vector = Color3.fromRGB(225, 225, 225),
             ["function"] = Color3.fromRGB(225, 225, 225),
+            ["thread"] = Color3.fromRGB(225, 225, 225),
             ["unnamed_function"] = Color3.fromRGB(175, 175, 175)
         }
     },

--- a/modules/RemoteSpy.lua
+++ b/modules/RemoteSpy.lua
@@ -111,7 +111,7 @@ for _name, hook in pairs(methodHooks) do
             if (not success) then return originalMethod(...) end
         end
 
-        if remotesViewing[instance.ClassName] and instance ~= remoteDataEvent then
+        if instance.ClassName == _name and remotesViewing[instance.ClassName] and instance ~= remoteDataEvent then
             local remote = currentRemotes[instance]
             local vargs = {select(2, ...)}
 


### PR DESCRIPTION
I fixed 2 problems.  

The first problem was that when a game passed a thread as an argument in a Remote/Bindable, Hydroxide would error because it attempted to get the icon and color for the type thread, but would see no such icon in init.lua.

The second problem was that a game could detect Hydroxide by using the indexed function of a Remote or Bindable, and then passing the wrong type of instance as the first argument.